### PR TITLE
Shell glob expansion does not always work inside of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+SHELLOPTS=braceexpand:emacs:hashall:histexpand:history:interactive-comments:monitor
 BAZEL_OPTS = -c opt --copt=-DABSL_MIN_LOG_LEVEL=absl::LogSeverity::kWarning
 
 all: docs/rust-client/pkg/rust_client.js docs/cc-client/brotli.js fonts


### PR DESCRIPTION
This command is failing with file not found for this argument which will not expanded by every shell being used:

- $(CURDIR)/subsets/{latin,cyrillic,vietnamese,greek}.txt

```build/roboto_table_keyed_config.txtpb: subsets/latin.txt subsets/cyrillic.txt subsets/vietnamese.txt subsets/greek.txt original_fonts/roboto_additional_config.txtpb
	bazel run $(BAZEL_OPTS) @ift_encoder//util:generate_table_keyed_config -- \
		$(CURDIR)/subsets/{latin,cyrillic,vietnamese,greek}.txt > $(CURDIR)/build/roboto_table_keyed_config.txtpb
	cat $(CURDIR)/original_fonts/roboto_additional_config.txtpb >> $(CURDIR)/build/roboto_table_keyed_config.txtpb
```
The fix is to nail the shell to e.g. bash which does so and set the shell options.
This way it works on linux, too.